### PR TITLE
Update workflows to add record_key

### DIFF
--- a/.github/workflows/e2e:full.yml
+++ b/.github/workflows/e2e:full.yml
@@ -49,3 +49,7 @@ jobs:
         uses: cypress-io/github-action@v1
         with:
           config-file: cypress-full.json
+          record: true
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/e2e:install-ui.yml
+++ b/.github/workflows/e2e:install-ui.yml
@@ -38,8 +38,13 @@ jobs:
         run: |
           sudo systemctl start mysql
           mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 13306
-
+      
+      
       - name: Cypress run
         uses: cypress-io/github-action@v1
         with:
-          config-file: cypress-install.json
+          config-file: cypress-full.json
+          record: true
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/e2e:install-ui.yml
+++ b/.github/workflows/e2e:install-ui.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v1
         with:
-          config-file: cypress-full.json
+          config-file: cypress-install.json
           record: true
         env:
           # pass the Dashboard record key as an environment variable


### PR DESCRIPTION
Updated workflows per instruction from @datitisev to include the record_key for integration back to the Cypress Dashboard.
**Requires review**